### PR TITLE
build: update golangci-lint, goreleaser and go version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,7 +111,8 @@ formatters:
     - goimports
   settings:
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
   exclusions:
     generated: lax
     paths:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 # https://asdf-vm.com/manage/configuration.html#tool-versions
-golangci-lint 2.12.2
+golangci-lint 2.13.0
 vhs 0.10.0
 task 3.49.1
-goreleaser 2.15.4
+goreleaser 2.17.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mchlumsky/mracek
 
-go 1.26.4
+go 1.27
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
# Summary

## Changes
- Update Smart, fast linters runner.

Usage:
  golangci-lint [flags]
  golangci-lint [command]

Available Commands:
  cache       Cache control and information.
  completion  Generate the autocompletion script for the specified shell
  config      Configuration file information and verification.
  custom      Build a version of golangci-lint with custom linters.
  fmt         Format Go source files.
  formatters  List current formatters configuration.
  help        Display extra help
  linters     List current linters configuration.
  migrate     Migrate configuration file from v1 to v2.
  run         Lint the code.
  version     Display the golangci-lint version.

Flags:
      --color string   Use color when printing; can be 'always', 'auto', or 'never' (default "auto")
  -h, --help           Help for a command
  -v, --verbose        Verbose output
      --version        Print version

Use "golangci-lint [command] --help" for more information about a command. version in 
- Update  version in 
- Bump Go version to 1.27 in 
